### PR TITLE
fix counter.kafka-bytes-* and add timestamps to datapoints

### DIFF
--- a/sfxbridge/maps/host.py
+++ b/sfxbridge/maps/host.py
@@ -265,7 +265,8 @@ class _CpuUtilization:
             "tags": metric.get("tags"),
             "fields": {
                 "utilization": round(100.0 - metric["fields"].get("usage_idle", 0.0), 2),
-            }
+            },
+            "timestamp": metric.get("timestamp")
         }
 
         self.metrics.append(result)
@@ -294,6 +295,7 @@ class _NetworkTotal:
     _metrics = None
     _interfaces = None
     _tags = None
+    _timestamp = None
 
     def __init__(self):
         self.clear()
@@ -317,7 +319,8 @@ class _NetworkTotal:
             "tags": self._tags,
             "fields": {
                 "total": total_bytes,
-            }
+            },
+            "timestamp": self._timestamp,
         }
         return [result]
 
@@ -332,6 +335,9 @@ class _NetworkTotal:
         interface = metric.get("tags", {}).get("interface", "all")
         if interface == "all":
             return
+
+        if self._timestamp is None:
+            self._timestamp = metric.get("timestamp")
 
         in_bytes = metric.get("fields", {}).get("bytes_recv", 0)
         out_bytes = metric.get("fields", {}).get("bytes_sent", 0)

--- a/sfxbridge/maps/metrics.py
+++ b/sfxbridge/maps/metrics.py
@@ -29,10 +29,13 @@ class Mappings:
 
 
 class Constructors:
+    class _sentinel:
+        pass
+
     constructors = {}
 
     @classmethod
-    def register(cls, arg: Optional[Any] = None, service: Optional[str] = None):
+    def register(cls, constructor: Optional[Any] = _sentinel, *, service: Optional[str] = None):
         def fn(constructor, *, cls, service):
             Mappings.register(service=service, mapping=constructor.Meta.mappings)
             if service not in cls.constructors:
@@ -41,13 +44,17 @@ class Constructors:
             return constructor
 
         if service is None:
-            return fn(arg, cls=cls, service=DEFAULT_MAPPING)
-        return partial(fn, cls=cls, service=service)
+            service = DEFAULT_MAPPING
+
+        if constructor is cls._sentinel:
+            return partial(fn, cls=cls, service=service)
+        return fn(constructor, cls=cls, service=service)
 
 
 def get_rules(*, service: Optional[str] = None):
-    mappings = Mappings.mappings[DEFAULT_MAPPING]
-    constructors = Constructors.constructors[DEFAULT_MAPPING]
+    mappings = Mappings.mappings[DEFAULT_MAPPING].copy()
+    constructors = Constructors.constructors[DEFAULT_MAPPING].copy()
+
     if service is not None:
         mappings.update(Mappings.mappings[service])
         constructors += Constructors.constructors[service]

--- a/sfxbridge/sfxbridge.py
+++ b/sfxbridge/sfxbridge.py
@@ -76,6 +76,7 @@ class SfxClient:
         if self._apikey:
             self._headers["X-SF-TOKEN"] = self._apikey
         self._timeout = self.config.get("timeout", 20.0)
+        self._trace = self.config.get("trace", False)
 
         # Whitelist determines which statistics are actually send, even though
         # the configuration has a list of glob patterns
@@ -133,6 +134,13 @@ class SfxClient:
         self._mapper.clear()
         self._mapper.process(metrics)
         self.send(self._mapper.datapoints)
+
+        if self._trace:
+            with open("trace.json", "a") as fp:
+                print("\nTELEGRAF DATA\n", file=fp)
+                json.dump(metrics, fp=fp, indent=2)
+                print("\nDATAPOINTS\n", file=fp)
+                json.dump(self._mapper.datapoints, fp=fp, indent=2)
 
     def send(self, points: dict):
         if not points:

--- a/tests/test_kafka_mapper.py
+++ b/tests/test_kafka_mapper.py
@@ -1,0 +1,244 @@
+# Copyright 2019, Aiven, https://aiven.io/
+from logging import getLogger
+
+from sfxbridge.mapper import Mapper
+from sfxbridge.maps.metrics import DataPointType
+
+log = getLogger(__name__)
+
+KAFKA_METRICS = [
+    {
+        "fields": {
+            "Count": 717688622
+        },
+        "name": "kafka.server:BrokerTopicMetrics.BytesInPerSec",
+        "tags": {
+            "cloud": "google-europe-west1",
+            "host": "k1-3",
+            "project": "aiven-system-services",
+            "service": "k1",
+            "service_type": "kafka"
+        },
+        "timestamp": 1571666310
+    },
+    {
+        "fields": {
+            "Count": 809457929
+        },
+        "name": "kafka.server:BrokerTopicMetrics.BytesOutPerSec",
+        "tags": {
+            "cloud": "google-europe-west1",
+            "host": "k1-3",
+            "project": "aiven-system-services",
+            "service": "k1",
+            "service_type": "kafka"
+        },
+        "timestamp": 1571666310
+    },
+    {
+        "fields": {
+            "Count": 717688622
+        },
+        "name": "kafka.server:BrokerTopicMetrics.BytesInPerSec",
+        "tags": {
+            "cloud": "google-europe-west1",
+            "host": "k1-3",
+            "project": "aiven-system-services",
+            "service": "k1",
+            "service_type": "kafka",
+            "topic": "foo-topic",
+        },
+        "timestamp": 1571666310
+    },
+    {
+        "fields": {
+            "Count": 809457929
+        },
+        "name": "kafka.server:BrokerTopicMetrics.BytesOutPerSec",
+        "tags": {
+            "cloud": "google-europe-west1",
+            "host": "k1-3",
+            "project": "aiven-system-services",
+            "service": "k1",
+            "service_type": "kafka",
+            "topic": "foo-topic",
+        },
+        "timestamp": 1571666310
+    },
+    {
+        "fields": {
+            "Count": 3473961
+        },
+        "name": "kafka.server:BrokerTopicMetrics.MessagesInPerSec",
+        "tags": {
+            "cloud": "google-europe-west1",
+            "host": "k1-3",
+            "project": "aiven-system-services",
+            "service": "k1",
+            "service_type": "kafka"
+        },
+        "timestamp": 1571666310
+    },
+    {
+        "fields": {
+            "Count": 3473961
+        },
+        "name": "kafka.server:BrokerTopicMetrics.MessagesInPerSec",
+        "tags": {
+            "cloud": "google-europe-west1",
+            "host": "k1-3",
+            "project": "aiven-system-services",
+            "service": "k1",
+            "service_type": "kafka",
+            "topic": "foo-topic",
+        },
+        "timestamp": 1571666310
+    },
+    {
+        "fields": {
+            "95thPercentile": 501,
+            "Count": 1246480,
+            "Mean": 326.74261440215645
+        },
+        "name": "kafka.network:RequestMetrics.TotalTimeMs",
+        "tags": {
+            "cloud": "google-europe-west1",
+            "host": "k1-3",
+            "project": "aiven-system-services",
+            "request": "FetchConsumer",
+            "service": "k1",
+            "service_type": "kafka"
+        },
+        "timestamp": 1571666310
+    },
+    {
+        "fields": {
+            "95thPercentile": 502,
+            "Count": 1932488,
+            "Mean": 397.2585371810847
+        },
+        "name": "kafka.network:RequestMetrics.TotalTimeMs",
+        "tags": {
+            "cloud": "google-europe-west1",
+            "host": "k1-3",
+            "project": "aiven-system-services",
+            "request": "FetchFollower",
+            "service": "k1",
+            "service_type": "kafka"
+        },
+        "timestamp": 1571666310
+    },
+    {
+        "fields": {
+            "95thPercentile": 3,
+            "Count": 299815,
+            "Mean": 1.7560395577272652
+        },
+        "name": "kafka.network:RequestMetrics.TotalTimeMs",
+        "tags": {
+            "cloud": "google-europe-west1",
+            "host": "k1-3",
+            "project": "aiven-system-services",
+            "request": "Produce",
+            "service": "k1",
+            "service_type": "kafka"
+        },
+        "timestamp": 1571666310
+    },
+]
+
+
+# Test constructed metrics
+def test_bytes_in_out():
+    mapper = Mapper(log=log, whitelist=["counter.kafka-bytes-in", "counter.kafka-bytes-out"], service="kafka")
+    mapper.process(KAFKA_METRICS)
+    assert mapper.datapoints == {
+        DataPointType.cumulative: [
+            {
+                "dimensions": {
+                    "cluster": "k1",
+                    "host": "k1-3",
+                    "hostHasService": "kafka",
+                },
+                "metric": "counter.kafka-bytes-in",
+                "value": 717688622,
+                "timestamp": 1571666310000,
+            },
+            {
+                "dimensions": {
+                    "cluster": "k1",
+                    "host": "k1-3",
+                    "hostHasService": "kafka",
+                },
+                "metric": "counter.kafka-bytes-out",
+                "value": 809457929,
+                "timestamp": 1571666310000,
+            },
+        ]
+    }
+
+
+def test_messages_in():
+    mapper = Mapper(log=log, whitelist=["counter.kafka-messages-in"], service="kafka")
+    mapper.process(KAFKA_METRICS)
+    assert mapper.datapoints == {
+        DataPointType.cumulative: [
+            {
+                "dimensions": {
+                    "cluster": "k1",
+                    "host": "k1-3",
+                    "hostHasService": "kafka"
+                },
+                "metric": "counter.kafka-messages-in",
+                "value": 3473961,
+                "timestamp": 1571666310000,
+            },
+        ]
+    }
+
+
+def test_request_metrics():
+    mapper = Mapper(
+        log=log,
+        whitelist=[
+            "counter.kafka.fetch-consumer.total_time.count",
+            "counter.kafka.fetch-follower.total_time.count",
+            "counter.kafka.produce.total_time.count",
+        ],
+        service="kafka",
+    )
+    mapper.process(KAFKA_METRICS)
+    assert mapper.datapoints == {
+        DataPointType.cumulative: [
+            {
+                "dimensions": {
+                    "cluster": "k1",
+                    "host": "k1-3",
+                    "hostHasService": "kafka",
+                },
+                "metric": "counter.kafka.fetch-consumer.total_time.count",
+                "value": 1246480,
+                "timestamp": 1571666310000,
+            },
+            {
+                "dimensions": {
+                    "cluster": "k1",
+                    "host": "k1-3",
+                    "hostHasService": "kafka",
+                },
+                "metric": "counter.kafka.fetch-follower.total_time.count",
+                "value": 1932488,
+                "timestamp": 1571666310000,
+            },
+            {
+                "dimensions": {
+                    "cluster": "k1",
+                    "host": "k1-3",
+                    "hostHasService": "kafka",
+                },
+                "metric": "counter.kafka.produce.total_time.count",
+                "value": 299815,
+                "timestamp": 1571666310000,
+            },
+        ],
+    }

--- a/tests/test_mapper.py
+++ b/tests/test_mapper.py
@@ -38,6 +38,7 @@ def test_simple_mapping():
             },
             "metric": "load.midterm",
             "value": 0.47,
+            "timestamp": 1570444470000,
         }]
     }
 
@@ -80,6 +81,7 @@ def test_cpu_utilization():
             },
             "metric": "cpu.utilization",
             "value": 9.07,
+            "timestamp": 1570444500000,
         }]
     }
 
@@ -126,7 +128,7 @@ def test_network_total():
                 "service": "pg",
                 "service_type": "pg"
             },
-            "timestamp": 1570444500
+            "timestamp": 1570444500,
         },
     ])
     assert mapper.datapoints == {
@@ -137,5 +139,6 @@ def test_network_total():
             },
             "metric": "network.total",
             "value": 156796692 + 24029619,
+            "timestamp": 1570444500000,
         }]
     }


### PR DESCRIPTION
Fixed the issue with counter.kafka-bytes-*
Added unittest for all constructed metrics
Added support for enabling trace.log file for debugging purposes
Fixed get_rules() (only manifested itself with pytest)