### PR TITLE
Support building on Fedora31

### DIFF
--- a/sfxbridge.spec
+++ b/sfxbridge.spec
@@ -6,7 +6,7 @@ Summary:        Bridge metrics from telegraf to SignalFX
 License:        ASL 2.0
 Source0:        sfxbridge-rpm-src.tar.gz
 Requires:       systemd-python3, python3-requests, python3-aiohttp
-BuildRequires:  %{requires}
+BuildRequires:  systemd-python3, python3-requests, python3-aiohttp
 BuildRequires:  python3-devel, python3-pytest, python3-pylint
 BuildArch:      noarch
 


### PR DESCRIPTION
Fedora31 brings with it stricter rules for spec files and the %{requires} macro is no longer valid for `BuildRequires`.